### PR TITLE
feat: add /divide route with input validation and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,5 +17,17 @@ def multiply():
     return jsonify(result=a * b)
 
 
+@app.route("/divide")
+def divide():
+    try:
+        a = float(request.args.get("a"))
+        b = floatrequest.args.get("b"))
+        if b == 0:
+            return jsonify(error="Cannot divide by zero"), 400
+        return jsonify(result=a / b)
+    except (TypeError, ValueError):
+        return jsonify(error="Invalid input"), 400
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ def multiply():
 def divide():
     try:
         a = float(request.args.get("a"))
-        b = floatrequest.args.get("b"))
+        b = float(request.args.get("b"))
         if b == 0:
             return jsonify(error="Cannot divide by zero"), 400
         return jsonify(result=a / b)

--- a/test_app.py
+++ b/test_app.py
@@ -33,4 +33,4 @@ def test_divide_invalid_input():
     with app.test_client() as client:
         response = client.get("/divide?a=x&b=3")
         assert response.status_code == 400
-        assert "error" on response.json
+        assert "error" in response.json

--- a/test_app.py
+++ b/test_app.py
@@ -13,3 +13,24 @@ def test_multiply():
         response = client.get("/multiply?a=2&b=3")
         assert response.status_code == 200
         assert response.json["result"] == 6
+
+
+def test_divide():
+    with app.test_client() as client:
+        response = client.get("/divide?a=6&b=2")
+        assert response.status_code == 200
+        assert response.json["result"] == 3.0
+
+
+def test_divide_by_zero():
+    with app.test_client() as client:
+        response = client.get("/divide?a=6&b=0")
+        assert response.status_code == 400
+        assert "error" in response.json
+
+
+def test_divide_invalid_input():
+    with app.test_client() as client:
+        response = client.get("/divide?a=x&b=3")
+        assert response.status_code == 400
+        assert "error" on response.json


### PR DESCRIPTION
## What was done?
- Implemented a new /divide route in app.py
- Added corresponding unit tests for:
- valid input
- divide by zero
- invalid input
- Tests added to `test_app.py`
---
## How to test it ?
Run the application:
`python app.py`
Send a GET request to:
`/divide?a=6&b=2`
Expected response:
`{"result": 3.0}`
Run automated tests:
`pytest`
All tests should pass.
## Why this change?
To expand the calculator's functionality by adding division support, in line with the goal of building a minimal API with arithmetic operations.

## Notes for reviewers
No special considerations - follow the same structure and logic as the existing /add and / multiply routes.

## Related isse / task
Closes: none (standalone feature)