### PR TITLE
feat: add /subtract endpoint with test case

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,5 +29,15 @@ def divide():
         return jsonify(error="Invalid input"), 400
 
 
+@app.route("/subtract")
+def subtract():
+    try:
+        a = float(request.args.get("a"))
+        b = float(request.args.get("b"))
+        return jsonify(result=a - b)
+    except (TypeError, ValueError):
+        return jsonify(error="Invalid input"), 400
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/test_app.py
+++ b/test_app.py
@@ -34,3 +34,17 @@ def test_divide_invalid_input():
         response = client.get("/divide?a=x&b=3")
         assert response.status_code == 400
         assert "error" in response.json
+
+
+def test_subtract():
+    with app.test_client() as client:
+        response = client.get("/subtract?a=4&b=2")
+        assert response.status_code == 200
+        assert response.json["result"] == 2.0
+
+
+def test_subtract_invalid_input():
+    with app.test_client() as client:
+        response = client.get("/divide?a=x&b=3")
+        assert response.status_code = 400
+        assert "error" in response.json

--- a/test_app.py
+++ b/test_app.py
@@ -46,5 +46,5 @@ def test_subtract():
 def test_subtract_invalid_input():
     with app.test_client() as client:
         response = client.get("/divide?a=x&b=3")
-        assert response.status_code = 400
+        assert response.status_code == 400
         assert "error" in response.json


### PR DESCRIPTION
## What was done?
- Implemented a new /subtract route in app.py
- Added corresponding unit tests for:
- valid input
- invalid input
- Tests added to `test_app.py`
---
## How to test it ?
Run the application:
`python app.py`
Send a GET request to:
`/subtract?a=4&b=2`
Expected response:
`{"result": 2.0}`
Run automated tests:
`pytest`
All tests should pass.
## Why this change?
To expand the calculator's functionality by adding subtraction support, in line with the goal of building a minimal API with arithmetic operations.

## Notes for reviewers
No special considerations - follow the same structure and logic as the existing /add and / multiply routes.

## Related issue / task
Closes: none (standalone feature)